### PR TITLE
Allow case insensitive file name for Makefiles

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -1,4 +1,5 @@
 .temp
+temp
 .vscode/**
 node_modules
 .vscode-test/**

--- a/src/Tasks/MakefileTaskProvider.ts
+++ b/src/Tasks/MakefileTaskProvider.ts
@@ -30,6 +30,7 @@ export class MakefileTaskProvider implements vscode.TaskProvider<vscode.Task | M
       return undefined;
     }
 
+    // TODO how to identify a Makefile to use when the task is being executed from VSCode's tasks.json ????
     const makefileUri: vscode.Uri = scope.uri.with({
       path: path.join(scope.uri.path, definition.relativeFolder ?? '', MAKEFILE),
     });

--- a/src/Tasks/getAvailableTasks.ts
+++ b/src/Tasks/getAvailableTasks.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import vscode from 'vscode';
 
-import { MAKEFILE } from '../shared/constants';
+import { MAKEFILE_GLOB } from '../shared/constants';
 import { showGenericErrorNotification } from '../shared/errorNotifications';
 import getOutputChannel from '../shared/getOutputChannel';
 import { findFilesInFolder, getValidWorkspaceFolders } from '../shared/workspaceFiles';
@@ -34,7 +34,7 @@ async function fetchAvailableTasks(): Promise<MakefileTask[]> {
 
   try {
     const promises = folders.map(async (folder) => {
-      const files = await findFilesInFolder(folder, `**/${MAKEFILE}`);
+      const files = await findFilesInFolder(folder, `**/${MAKEFILE_GLOB}`);
       const tasksPromises = files.map((file) => buildTasksFromMakefile(file, folder));
 
       return (await Promise.all(tasksPromises)).flat();

--- a/src/TreeView/TreeViewItems.ts
+++ b/src/TreeView/TreeViewItems.ts
@@ -75,6 +75,7 @@ export class TasksJsonItem extends TaskHostFileItem {
   constructor(parent: FolderItem) {
     super(parent, TasksJsonItem.getLabel(), Expanded);
 
+    // TODO use the actual Makefile file name
     this.contextValue = MAKEFILE;
     this.resourceUri = vscode.Uri.file(
       path.join(parent.resourceUri?.fsPath ?? '', this.label ?? ''),
@@ -85,6 +86,7 @@ export class TasksJsonItem extends TaskHostFileItem {
 
 export class MakefileItem extends TaskHostFileItem {
   static getLabel(relativePath: string): string {
+    // TODO stop using MAKEFILE constant
     if (relativePath.length > 0) {
       return path.join(relativePath, MAKEFILE);
     }
@@ -95,8 +97,10 @@ export class MakefileItem extends TaskHostFileItem {
   constructor(parent: FolderItem, relativePath: string) {
     super(parent, MakefileItem.getLabel(relativePath), Expanded);
 
+    // TODO use the actual Makefile name
     this.contextValue = MAKEFILE;
 
+    // TODO replace relative path with the actual Makefile path
     this.resourceUri = vscode.Uri.file(
       path.join(parent.resourceUri?.fsPath ?? '', relativePath, MAKEFILE),
     );

--- a/src/TreeView/taskTreeBuilder.ts
+++ b/src/TreeView/taskTreeBuilder.ts
@@ -67,6 +67,7 @@ function getTaskHostFileItem(
       folderItem.addChild(item);
     }
   } else {
+    // TODO get full path to the actual Makefile containing the target
     const relativePath = task.definition.relativeFolder ?? '';
     const fullPath = path.join(scope.name, relativePath, MAKEFILE);
     item = map.get(fullPath);

--- a/src/commandPicker/runFromCommandPicker.ts
+++ b/src/commandPicker/runFromCommandPicker.ts
@@ -33,18 +33,12 @@ export async function runFromCommandPicker(taskProvider?: MakefileTaskProvider):
 
   if (selectedTarget) {
     vscode.tasks.executeTask(selectedTarget);
-    trackEvent({
-      action: 'Run Command',
-      category: 'CommandPicker',
-      label: 'runTarget',
-      value: selectedTarget.name,
-    });
-  } else {
-    trackEvent({
-      action: 'Run Command',
-      category: 'CommandPicker',
-      label: 'runTarget',
-      value: 'userCancelled',
-    });
   }
+
+  trackEvent({
+    action: 'Run Command',
+    category: 'CommandPicker',
+    label: 'runTarget',
+    value: selectedTarget?.name ?? 'userCancelled',
+  });
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,7 +2,7 @@ import vscode from 'vscode';
 
 import { registerCommands } from './commandPicker/commandsManager';
 import { COMMANDS } from './shared/config';
-import { MAKEFILE } from './shared/constants';
+import { MAKEFILE_GLOB } from './shared/constants';
 import registerTaskProvider from './Tasks/registerTaskProvider';
 import { getTracker, trackEvent } from './telemetry/tracking';
 import { registerTreeViewProvider } from './TreeView/registerTreeViewProvider';
@@ -20,7 +20,7 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(runRefreshCommand));
 
   if (vscode.workspace.workspaceFolders) {
-    const watcher = vscode.workspace.createFileSystemWatcher(`**/${MAKEFILE}`);
+    const watcher = vscode.workspace.createFileSystemWatcher(`**/${MAKEFILE_GLOB}`);
     watcher.onDidChange(runRefreshCommand);
     watcher.onDidDelete(runRefreshCommand);
     watcher.onDidCreate(runRefreshCommand);

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -2,8 +2,17 @@ export const APP_NAME = 'make-task-provider';
 
 /**
  * Preferred file name of the Makefile
+ * @deprecated
  */
 export const MAKEFILE = 'Makefile'; // TODO get the Makefile name from config
+
+/**
+ * Glob to match `M` or `m` in the file name
+ *
+ * As suggested in the official {@link https://www.gnu.org/software/make/manual/html_node/Makefile-Names.html Docs},
+ * make is case insensitive regarding the default file names.
+ */
+export const MAKEFILE_GLOB = '{M,m}akefile';
 
 /**
  * Task provider type name


### PR DESCRIPTION
#6 

According to the [official Docs](https://www.gnu.org/software/make/manual/html_node/Makefile-Names.html), `Make` is case **insensitive** regarding the default `Makefile` file name. 

This PR enable it. 