### PR TITLE
Customize makefile name

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,7 +5,9 @@
   "editor.formatOnSave": false,
   "eslint.packageManager": "yarn",
   "npm.packageManager": "yarn",
-  "prettier.packageManager": "yarn",
   "typescript.tsc.autoDetect": "off",
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "editor.rulers": [
+    100,
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 2.0.0 (2021-08-09)
+
+* Allow using any name for the Makefile ([12e4042](https://github.com/carlos-algms/vscode-make-task-provider/commit/12e4042))
+* Display the right file name in the tasks tree ([8640789](https://github.com/carlos-algms/vscode-make-task-provider/commit/8640789))
+* Use the right Makefile when executing a target ([4546f2c](https://github.com/carlos-algms/vscode-make-task-provider/commit/4546f2c))
+
+
+
 ## 1.5.0 (2021-08-02)
 
 * Allow case insensitive file name for Makefiles (#8) ([7d21b50](https://github.com/carlos-algms/vscode-make-task-provider/commit/7d21b50)), closes [#8](https://github.com/carlos-algms/vscode-make-task-provider/issues/8)

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Run `make` tasks and targets from VS Code command picker or via tasks menu.
   - **Terminal -> Run task**
 - Tasks-View listing all available targets
 - Multiple workspaces ready!
-- **NEW** set the executable path to your `make` command
+- **NEW**: Set the executable path to your `make` command
 
 ### Running from the command picker:
 

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
             "type": "string",
             "description": "The make target name to run. Must exist in your Makefile"
           },
-          "relativeFolder": {
+          "makeFileRelativePath": {
             "type": "string",
-            "description": "Relative path to the folder where the Makefile is located in the Workspace"
+            "description": "Relative path to the Makefile containing your targets to be executed"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.5.0",
+  "version": "2.0.0",
   "name": "make-task-provider",
   "publisher": "carlos-algms",
   "displayName": "Make support and task provider",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
       {
         "type": "make",
         "required": [
-          "targetName"
+          "targetName",
+          "makeFileRelativePath"
         ],
         "properties": {
           "targetName": {
@@ -121,31 +122,40 @@
           "scope": "resource",
           "type": "boolean",
           "default": true,
-          "description": "Controls whether auto detection of Make tasks is on or off. Default is on."
+          "description": "Controls whether auto detection of Make tasks is on or off.\nDefault is on."
         },
         "make-task-provider.telemetry": {
           "scope": "resource",
           "type": "boolean",
           "default": true,
-          "description": "Enable usage data and errors to be sent to an online service. We follow Microsoft's privacy statement, please, find it here [here](https://go.microsoft.com/fwlink/?LinkId=786907)"
+          "description": "Enable usage data and errors to be sent to an online service.\nWe follow Microsoft's privacy statement, please, find it [here](https://go.microsoft.com/fwlink/?LinkId=786907)"
         },
         "make-task-provider.windows.makeExecutable": {
           "scope": "resource",
           "type": "string",
           "default": null,
-          "description": "The executable path to your make command in the Windows environment, i.e: \"C:\\Program Files\\make\\bin\\make.exe\", please use a correct path, this is just an example."
+          "description": "The executable path to your make command in the Windows environment. \ni.e: \"C:\\Program Files\\make\\bin\\make.exe\"\nplease use a correct path, this is just an example."
         },
         "make-task-provider.unix.makeExecutable": {
           "scope": "resource",
           "type": "string",
           "default": null,
-          "description": "The executable path to your make command in the Unix environment, i.e: \"/usr/bin/make\", please use a correct path, this is just an example."
+          "description": "The executable path to your make command in the Unix environment.\ni.e: \"/usr/bin/make\"\nplease use a correct path, this is just an example."
         },
         "make-task-provider.osx.makeExecutable": {
           "scope": "resource",
           "type": "string",
           "default": null,
-          "description": "The executable path to your make command in the MacOS environment, i.e: \"/usr/bin/make\", please use a correct path, this is just an example."
+          "description": "The executable path to your make command in the MacOS environment.\ni.e: \"/usr/bin/make\"\nplease use a correct path, this is just an example."
+        },
+        "make-task-provider.makefileNames": {
+          "scope": "resource",
+          "type": "array",
+          "default": [
+            "makefile",
+            "Makefile"
+          ],
+          "description": "A list of file names that the extension should look for while searching the workspace.\nThis allows you to have non-standard name for your file."
         }
       }
     }

--- a/src/Tasks/MakefileTask.ts
+++ b/src/Tasks/MakefileTask.ts
@@ -8,9 +8,9 @@ export interface MakefileTaskDefinition extends vscode.TaskDefinition {
   targetName: string;
 
   /**
-   * Relative folder path where the Makefile is stored
+   * The relative path to the Makefile containing the Target task
    */
-  relativeFolder?: string;
+  makeFileRelativePath: string;
 }
 
 export interface MakefileTask extends vscode.Task {

--- a/src/Tasks/MakefileTaskProvider.ts
+++ b/src/Tasks/MakefileTaskProvider.ts
@@ -1,8 +1,6 @@
 import path from 'path';
 import vscode from 'vscode';
 
-import { MAKEFILE } from '../shared/constants';
-
 import { createMakefileTask } from './createMakefileTask';
 import getAvailableTasks from './getAvailableTasks';
 import { MakefileTask } from './MakefileTask';
@@ -30,9 +28,8 @@ export class MakefileTaskProvider implements vscode.TaskProvider<vscode.Task | M
       return undefined;
     }
 
-    // TODO how to identify a Makefile to use when the task is being executed from VSCode's tasks.json ????
     const makefileUri: vscode.Uri = scope.uri.with({
-      path: path.join(scope.uri.path, definition.relativeFolder ?? '', MAKEFILE),
+      path: path.join(scope.uri.path, definition.makeFileRelativePath),
     });
 
     const providedTask = createMakefileTask(definition, scope, makefileUri);

--- a/src/Tasks/createMakefileTask.ts
+++ b/src/Tasks/createMakefileTask.ts
@@ -35,9 +35,10 @@ export function createMakefileTask(
   makefileUri: vscode.Uri,
 ): MakefileTask {
   const definition = getDefinition(nameOrDefinition, folder, makefileUri);
-  const { targetName } = definition;
+  const { targetName, makeFileRelativePath } = definition;
 
   const cwd = path.dirname(makefileUri.fsPath);
+  const makefile = path.basename(makeFileRelativePath);
 
   const options: vscode.ShellExecutionOptions = { cwd };
   // TODO: check performance degradation here
@@ -49,7 +50,7 @@ export function createMakefileTask(
       folder,
       targetName,
       TYPE,
-      new vscode.ShellExecution(makeBin, [targetName], options),
+      new vscode.ShellExecution(makeBin, ['-f', makefile, targetName], options),
       [],
     )
   );

--- a/src/Tasks/createMakefileTask.ts
+++ b/src/Tasks/createMakefileTask.ts
@@ -3,7 +3,7 @@ import vscode from 'vscode';
 
 import { getMakeExecutablePath } from '../shared/config';
 import { TYPE } from '../shared/constants';
-import { getParentRelativePath } from '../shared/workspaceUtils';
+import { getFileRelativePath } from '../shared/workspaceUtils';
 
 import { MakefileTask, MakefileTaskDefinition } from './MakefileTask';
 import { getTaskGroupGuess } from './taskGroup';
@@ -20,9 +20,9 @@ export function getDefinition(
 ): MakefileTaskDefinition {
   if (typeof nameOrDefinition === 'string') {
     return {
-      type: 'make',
+      type: TYPE,
       targetName: nameOrDefinition,
-      relativeFolder: getParentRelativePath(makefileUri, folder),
+      makeFileRelativePath: getFileRelativePath(makefileUri, folder),
     };
   }
 

--- a/src/Tasks/getAvailableTasks.ts
+++ b/src/Tasks/getAvailableTasks.ts
@@ -1,7 +1,7 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 import vscode from 'vscode';
 
-import { MAKEFILE_GLOB } from '../shared/constants';
+import { getMakefileNames } from '../shared/config';
 import { showGenericErrorNotification } from '../shared/errorNotifications';
 import getOutputChannel from '../shared/getOutputChannel';
 import { findFilesInFolder, getValidWorkspaceFolders } from '../shared/workspaceFiles';
@@ -33,8 +33,11 @@ async function fetchAvailableTasks(): Promise<MakefileTask[]> {
   }
 
   try {
+    const makefileNames = getMakefileNames();
+    const glob = `**/{${makefileNames.join(',')}}`;
+
     const promises = folders.map(async (folder) => {
-      const files = await findFilesInFolder(folder, `**/${MAKEFILE_GLOB}`);
+      const files = await findFilesInFolder(folder, glob);
       const tasksPromises = files.map((file) => buildTasksFromMakefile(file, folder));
 
       return (await Promise.all(tasksPromises)).flat();

--- a/src/Tasks/getMakefileTargetNames.ts
+++ b/src/Tasks/getMakefileTargetNames.ts
@@ -23,7 +23,8 @@ export default async function getMakefileTargetNames(
     }
 
     const makeBin = getMakeExecutablePath(folder);
-    const cmd = `${makeBin} ${MAKE_PARAMS}`;
+    const makefile = path.basename(makefileUri.fsPath);
+    const cmd = `${makeBin} -f ${makefile} ${MAKE_PARAMS}`;
 
     const rootPath = path.dirname(makefileUri.fsPath);
 

--- a/src/TreeView/TreeViewItems.ts
+++ b/src/TreeView/TreeViewItems.ts
@@ -63,8 +63,15 @@ export class FolderItem extends BaseTreeItem<null, TaskHostFileItem> {
   }
 }
 
+/**
+ * Represents one file containing tasks to be executed
+ * Could be a Makefile or the tasks.json
+ */
 export class TaskHostFileItem extends BaseTreeItem<FolderItem> {}
 
+/**
+ * Represents the tasks.json file
+ */
 export class TasksJsonItem extends TaskHostFileItem {
   private static fixedLabel: string = path.join('.vscode', 'tasks.json');
 
@@ -75,7 +82,6 @@ export class TasksJsonItem extends TaskHostFileItem {
   constructor(parent: FolderItem) {
     super(parent, TasksJsonItem.getLabel(), Expanded);
 
-    // TODO use the actual Makefile file name
     this.contextValue = MAKEFILE;
     this.resourceUri = vscode.Uri.file(
       path.join(parent.resourceUri?.fsPath ?? '', this.label ?? ''),
@@ -84,30 +90,25 @@ export class TasksJsonItem extends TaskHostFileItem {
   }
 }
 
+/**
+ * Represents a Makefile within the Workspace
+ */
 export class MakefileItem extends TaskHostFileItem {
-  static getLabel(relativePath: string): string {
-    // TODO stop using MAKEFILE constant
-    if (relativePath.length > 0) {
-      return path.join(relativePath, MAKEFILE);
-    }
+  constructor(parent: FolderItem, makeFileRelativePath: string) {
+    super(parent, makeFileRelativePath, Expanded);
 
-    return MAKEFILE;
-  }
-
-  constructor(parent: FolderItem, relativePath: string) {
-    super(parent, MakefileItem.getLabel(relativePath), Expanded);
-
-    // TODO use the actual Makefile name
     this.contextValue = MAKEFILE;
 
-    // TODO replace relative path with the actual Makefile path
     this.resourceUri = vscode.Uri.file(
-      path.join(parent.resourceUri?.fsPath ?? '', relativePath, MAKEFILE),
+      path.join(parent.resourceUri?.fsPath ?? '', makeFileRelativePath),
     );
     this.iconPath = vscode.ThemeIcon.File;
   }
 }
 
+/**
+ * Represents an executable target from within a Makefile or tasks.json
+ */
 export class MakefileTargetItem extends BaseTreeItem<MakefileItem> {
   task: MakefileTask;
 
@@ -118,7 +119,7 @@ export class MakefileTargetItem extends BaseTreeItem<MakefileItem> {
 
     this.contextValue = 'MakefileTarget';
 
-    // TODO read the default click action from the config, run, or open the file at the script position
+    // TODO read the default click action from the config, run or open the file at the script position
     this.command = {
       title: 'Run this target',
       command: COMMANDS.runTargetFromTreeView,

--- a/src/TreeView/registerTreeViewProvider.ts
+++ b/src/TreeView/registerTreeViewProvider.ts
@@ -22,8 +22,14 @@ export function registerTreeViewProvider(
     }),
 
     vscode.workspace.onDidChangeConfiguration((e) => {
-      if (e.affectsConfiguration(CONFIG_KEYS.autoDetect)) {
+      const shouldInvalidate =
+        e.affectsConfiguration(CONFIG_KEYS.autoDetect) ||
+        e.affectsConfiguration(CONFIG_KEYS.makeExecutable) ||
+        e.affectsConfiguration(CONFIG_KEYS.makefileNames);
+
+      if (shouldInvalidate) {
         invalidateTaskCaches();
+
         if (treeDataProvider) {
           treeDataProvider.refresh();
         }

--- a/src/TreeView/taskTreeBuilder.ts
+++ b/src/TreeView/taskTreeBuilder.ts
@@ -1,7 +1,5 @@
-import path from 'path';
 import vscode from 'vscode';
 
-import { MAKEFILE } from '../shared/constants';
 import { isWorkspaceFolder } from '../shared/workspaceUtils';
 import { MakefileTask } from '../Tasks/MakefileTask';
 
@@ -67,14 +65,12 @@ function getTaskHostFileItem(
       folderItem.addChild(item);
     }
   } else {
-    // TODO get full path to the actual Makefile containing the target
-    const relativePath = task.definition.relativeFolder ?? '';
-    const fullPath = path.join(scope.name, relativePath, MAKEFILE);
-    item = map.get(fullPath);
+    const makeFileRelativePath = task.definition.makeFileRelativePath ?? '';
+    item = map.get(makeFileRelativePath);
 
     if (!item) {
-      item = new MakefileItem(folderItem, relativePath);
-      map.set(fullPath, item);
+      item = new MakefileItem(folderItem, makeFileRelativePath);
+      map.set(makeFileRelativePath, item);
       folderItem.addChild(item);
     }
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,8 +1,7 @@
 import vscode from 'vscode';
 
 import { registerCommands } from './commandPicker/commandsManager';
-import { COMMANDS } from './shared/config';
-import { MAKEFILE_GLOB } from './shared/constants';
+import { COMMANDS, getMakefileNames } from './shared/config';
 import registerTaskProvider from './Tasks/registerTaskProvider';
 import { getTracker, trackEvent } from './telemetry/tracking';
 import { registerTreeViewProvider } from './TreeView/registerTreeViewProvider';
@@ -20,10 +19,14 @@ export function activate(context: vscode.ExtensionContext): void {
   context.subscriptions.push(vscode.workspace.onDidChangeWorkspaceFolders(runRefreshCommand));
 
   if (vscode.workspace.workspaceFolders) {
-    const watcher = vscode.workspace.createFileSystemWatcher(`**/${MAKEFILE_GLOB}`);
+    const makefileNames = getMakefileNames();
+    const glob = `**/{${makefileNames.join(',')}}`;
+    const watcher = vscode.workspace.createFileSystemWatcher(glob);
+
     watcher.onDidChange(runRefreshCommand);
     watcher.onDidDelete(runRefreshCommand);
     watcher.onDidCreate(runRefreshCommand);
+
     context.subscriptions.push(watcher);
   }
 

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,12 +1,23 @@
 import { platform } from 'os';
 import vscode from 'vscode';
 
+import { contributes } from '../../package.json';
 import { trackEvent } from '../telemetry/tracking';
 
 import { APP_NAME } from './constants';
 
+const {
+  configuration: {
+    properties: {
+      'make-task-provider.makefileNames': { default: defaultMakefileNames },
+    },
+  },
+} = contributes;
+
 export const CONFIG_KEYS = {
   autoDetect: `${APP_NAME}.autoDetect`,
+  makefileNames: `${APP_NAME}.makefileNames`,
+  makeExecutable: `${APP_NAME}.${getUserPlatformKey() ?? 'unix.makeExecutable'}`,
 };
 
 export const COMMANDS = {
@@ -62,6 +73,10 @@ export function getMakeExecutablePath(folder?: vscode.WorkspaceFolder): string {
   }
 
   return executablePath;
+}
+
+export function getMakefileNames(folder?: vscode.WorkspaceFolder): string[] {
+  return getFolderConfig(folder).get<string[]>('makefileNames', defaultMakefileNames);
 }
 
 export function getUserPlatformKey(): string | null {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,10 +1,6 @@
 export const APP_NAME = 'make-task-provider';
 
-/**
- * Preferred file name of the Makefile
- * @deprecated
- */
-export const MAKEFILE = 'Makefile'; // TODO get the Makefile name from config
+export const MAKEFILE = 'Makefile';
 
 /**
  * Glob to match `M` or `m` in the file name

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -3,14 +3,6 @@ export const APP_NAME = 'make-task-provider';
 export const MAKEFILE = 'Makefile';
 
 /**
- * Glob to match `M` or `m` in the file name
- *
- * As suggested in the official {@link https://www.gnu.org/software/make/manual/html_node/Makefile-Names.html Docs},
- * make is case insensitive regarding the default file names.
- */
-export const MAKEFILE_GLOB = '{M,m}akefile';
-
-/**
  * Task provider type name
  */
 export const TYPE = 'make';

--- a/src/shared/workspaceUtils.ts
+++ b/src/shared/workspaceUtils.ts
@@ -14,13 +14,3 @@ export function getFileRelativePath(fileUri: vscode.Uri, folder: vscode.Workspac
   const rootUri = folder.uri;
   return absolutePath.substring(rootUri.path.length + 1);
 }
-
-/**
- * Get the relative path to a given file's parent directory without trailing slash
- */
-export function getParentRelativePath(fileUri: vscode.Uri, folder: vscode.WorkspaceFolder): string {
-  const relativePath = getFileRelativePath(fileUri, folder);
-  const lastPart = path.basename(relativePath);
-  const parentPath = relativePath.substring(0, relativePath.length - lastPart.length - 1);
-  return parentPath;
-}


### PR DESCRIPTION
[BREAKING CHANGE]:
To enable this feature it was necessary to replace the `relativeFolder`
with `makeFileRelativePath` to specifically target a file.

If you set any task in your `tasks.json` you need to update it manually.