### PR TITLE
feat: Option to open or run a target from the Tree-View

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,8 @@ Run `make` tasks and targets from VS Code command picker or via tasks menu.
 
 ---
 
-**PS:** This extension is not a re-implementation of `make`, so you need to have `make` executables available on your system.
+**PS:** This extension is **NOT** a re-implementation of `make`,
+so you need to have `make` executables available on your system.
 
 If `make` is not on your `PATH`, you can customize the executable path individually based on your operating system:
 

--- a/package.json
+++ b/package.json
@@ -67,6 +67,10 @@
         "command": "make-task-provider.refresh",
         "title": "Refresh",
         "icon": "$(refresh)"
+      },
+      {
+        "command": "make-task-provider.targetFromTreeViewClicked",
+        "title": "target clicked"
       }
     ],
     "menus": {
@@ -77,6 +81,10 @@
         },
         {
           "command": "make-task-provider.refresh",
+          "when": "false"
+        },
+        {
+          "command": "make-task-provider.targetFromTreeViewClicked",
           "when": "false"
         }
       ],
@@ -146,6 +154,16 @@
             "Makefile"
           ],
           "description": "A list of file names that the extension should look for while searching the workspace.\nThis allows you to have non-standard name for your file."
+        },
+        "make-task-provider.targetsExplorerClickAction": {
+          "scope": "resource",
+          "type": "string",
+          "default": "run",
+          "enum": [
+            "run",
+            "open"
+          ],
+          "markdownDescription": "The action to trigger when clicking on a target on the targets list: `open` or `run`, the default is `run`."
         }
       }
     }

--- a/src/Parsers/selectionFinder.test.ts
+++ b/src/Parsers/selectionFinder.test.ts
@@ -1,0 +1,39 @@
+import { getSelectionForTarget } from './selectionFinder';
+
+describe('Selection Finder', () => {
+  const text = `foo:
+  \techo foo
+
+  bar:
+  \techo bar
+  `;
+
+  it('should find the target and select it', () => {
+    const target = 'bar';
+    const selection = getSelectionForTarget(text, target);
+
+    const { anchor, active } = selection;
+    [anchor.line, anchor.character, active.line, active.character].should.eql([
+      3,
+      0,
+      3,
+      target.length + 1,
+    ]);
+  });
+
+  it('should just open the file on the beginning when a target is not found', () => {
+    const target = 'baz';
+    const selection = getSelectionForTarget(text, target);
+
+    const { anchor, active } = selection;
+    [anchor.line, anchor.character, active.line, active.character].should.eql([0, 0, 0, 0]);
+  });
+
+  it('should open the file on the beginning if no target name was provided', () => {
+    const target = undefined;
+    const selection = getSelectionForTarget(text, target);
+
+    const { anchor, active } = selection;
+    [anchor.line, anchor.character, active.line, active.character].should.eql([0, 0, 0, 0]);
+  });
+});

--- a/src/Parsers/selectionFinder.ts
+++ b/src/Parsers/selectionFinder.ts
@@ -1,0 +1,17 @@
+import vscode from 'vscode';
+
+export function getSelectionForTarget(documentText: string, targetName?: string): vscode.Selection {
+  if (!targetName) {
+    return new vscode.Selection(0, 0, 0, 0);
+  }
+
+  const taskName = `${targetName}:`;
+  const documentLines = documentText.split('\n');
+  const lineNumber = documentLines.findIndex((line) => line.includes(taskName));
+
+  if (lineNumber === -1) {
+    return new vscode.Selection(0, 0, 0, 0);
+  }
+
+  return new vscode.Selection(lineNumber, 0, lineNumber, taskName.length);
+}

--- a/src/TreeView/MakefileTreeDataProvider.ts
+++ b/src/TreeView/MakefileTreeDataProvider.ts
@@ -1,5 +1,6 @@
 import vscode from 'vscode';
 
+import { getSelectionForTarget } from '../Parsers/selectionFinder';
 import {
   COMMANDS,
   CONFIG_KEYS,
@@ -92,28 +93,13 @@ export class MakefileTreeDataProvider
     }
 
     const document: vscode.TextDocument = await vscode.workspace.openTextDocument(uri);
-    const selection = this.findTargetPosition(document, targetItem);
+    const selection = getSelectionForTarget(document.getText(), targetItem?.label);
 
     await vscode.window.showTextDocument(document, {
       preserveFocus: true,
       selection,
     });
   };
-
-  private findTargetPosition(
-    document: vscode.TextDocument,
-    targetItem?: MakefileTargetItem,
-  ): vscode.Selection {
-    if (!targetItem) {
-      return new vscode.Selection(0, 0, 0, 0);
-    }
-
-    const taskName = `${targetItem.label}:`;
-    const documentLines = document.getText().split('\n');
-    const lineNumber = documentLines.findIndex((line) => line.includes(taskName));
-
-    return new vscode.Selection(lineNumber, 0, lineNumber, taskName.length);
-  }
 
   async getChildren(element?: BaseTreeItem): Promise<vscode.TreeItem[] | null | undefined> {
     if (!element) {

--- a/src/TreeView/TreeViewItems.ts
+++ b/src/TreeView/TreeViewItems.ts
@@ -119,10 +119,9 @@ export class MakefileTargetItem extends BaseTreeItem<MakefileItem> {
 
     this.contextValue = 'MakefileTarget';
 
-    // TODO read the default click action from the config, run or open the file at the script position
     this.command = {
       title: 'Run this target',
-      command: COMMANDS.runTargetFromTreeView,
+      command: COMMANDS.targetFromTreeViewClicked,
       arguments: [this],
     };
 

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -32,6 +32,11 @@ export const COMMANDS = {
    * Should invalidate all caches and refresh the tree-view
    */
   refresh: `${APP_NAME}.refresh`,
+
+  /**
+   * Triggered when a `target` from the tree-view is clicked
+   */
+  targetFromTreeViewClicked: `${APP_NAME}.targetFromTreeViewClicked`,
 };
 
 // TODO use common excludes from user config and also provide a custom exclude setting
@@ -89,4 +94,8 @@ export function getUserPlatformKey(): string | null {
       });
       return null;
   }
+}
+
+export function getTargetsExplorerClickAction(scope?: vscode.ConfigurationScope): 'run' | 'open' {
+  return getFolderConfig(scope).get<'run' | 'open'>('targetsExplorerClickAction', 'run');
 }


### PR DESCRIPTION
New configuration added: `make-task-provider.targetsExplorerClickAction` 
with two available options:

- `run`
- `open`

To avoid confusing previous users, the **default** was kept to `run` 

Fixes #14 