### PR TITLE
fix: The go-to command now matches the entire target name

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,7 +10,10 @@
       "type": "extensionHost",
       "request": "launch",
       "sourceMaps": true,
-      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "${workspaceFolder}/src/test/examples/case-1"
+      ],
       "outFiles": ["${workspaceFolder}/build/**/*.js"],
       "preLaunchTask": "${defaultBuildTask}"
     },

--- a/src/Parsers/selectionFinder.test.ts
+++ b/src/Parsers/selectionFinder.test.ts
@@ -2,10 +2,13 @@ import { getSelectionForTarget } from './selectionFinder';
 
 describe('Selection Finder', () => {
   const text = `foo:
-  \techo foo
+\techo foo
 
-  bar:
-  \techo bar
+false_bar:
+\techo false_bar:
+
+bar:
+\techo bar
   `;
 
   it('should find the target and select it', () => {
@@ -14,9 +17,9 @@ describe('Selection Finder', () => {
 
     const { anchor, active } = selection;
     [anchor.line, anchor.character, active.line, active.character].should.eql([
-      3,
+      6,
       0,
-      3,
+      6,
       target.length + 1,
     ]);
   });

--- a/src/Parsers/selectionFinder.ts
+++ b/src/Parsers/selectionFinder.ts
@@ -7,7 +7,7 @@ export function getSelectionForTarget(documentText: string, targetName?: string)
 
   const taskName = `${targetName}:`;
   const documentLines = documentText.split('\n');
-  const lineNumber = documentLines.findIndex((line) => line.includes(taskName));
+  const lineNumber = documentLines.findIndex((line) => line.trim().startsWith(taskName));
 
   if (lineNumber === -1) {
     return new vscode.Selection(0, 0, 0, 0);


### PR DESCRIPTION
It fixes the cases where multiple targets would end with the same name like:

```make
test_compile:
  ....

compile:
  ....
```

before, the command go-to `compile` would select the first line as it "contains" the `compile` word. 
