### PR TITLE
fix: Change the parser to add support for double colon rules

### DIFF
--- a/src/CodeLens/CodeLensProvider.test.ts
+++ b/src/CodeLens/CodeLensProvider.test.ts
@@ -2,10 +2,11 @@ import path from 'path';
 import vscode from 'vscode';
 
 import { COMMANDS } from '../shared/config';
+import { makeTasksResult } from '../test/examples/case-1/expectedResults';
 
 import { MakefileCodeLensProvider } from './CodeLensProvider';
 
-describe.only('CodeLensProvider', () => {
+describe('CodeLensProvider', () => {
   let document: vscode.TextDocument;
 
   beforeEach(async () => {
@@ -18,7 +19,7 @@ describe.only('CodeLensProvider', () => {
     const instance = new MakefileCodeLensProvider();
     const lenses = instance.provideCodeLenses(document);
 
-    lenses.should.have.length(3);
+    lenses.should.have.length(makeTasksResult.length);
     lenses.forEach((lens) => {
       expect(lens).to.be.instanceOf(vscode.CodeLens);
       expect(lens.command).to.exist;

--- a/src/Parsers/makefileParser.test.ts
+++ b/src/Parsers/makefileParser.test.ts
@@ -1,6 +1,8 @@
 import path from 'path';
 import vscode from 'vscode';
 
+import { makeTasksResult } from '../test/examples/case-1/expectedResults';
+
 import { makefileParser } from './makefileParser';
 
 describe('Makefile Parser', () => {
@@ -15,13 +17,6 @@ describe('Makefile Parser', () => {
 
     const targetNames = await makefileParser(makefilePath);
 
-    expect(targetNames).to.eql([
-      'foo',
-      'build',
-      'test',
-      'double-colon',
-      'double-colon-with-space',
-      'double-requisites',
-    ]);
+    expect(targetNames).to.eql(makeTasksResult);
   });
 });

--- a/src/Parsers/makefileParser.test.ts
+++ b/src/Parsers/makefileParser.test.ts
@@ -15,6 +15,13 @@ describe('Makefile Parser', () => {
 
     const targetNames = await makefileParser(makefilePath);
 
-    expect(targetNames).to.eql(['foo', 'build', 'test']);
+    expect(targetNames).to.eql([
+      'foo',
+      'build',
+      'test',
+      'double-colon',
+      'double-colon-with-space',
+      'double-requisites',
+    ]);
   });
 });

--- a/src/Parsers/makefileParser.ts
+++ b/src/Parsers/makefileParser.ts
@@ -6,9 +6,10 @@ import { trackException, trackExecutionTime } from '../telemetry/tracking';
  * - special targets: https://www.gnu.org/software/make/manual/html_node/Special-Targets.html
  * - suffix rules: https://www.gnu.org/software/make/manual/html_node/Suffix-Rules.html
  * - pattern rules: https://www.gnu.org/software/make/manual/html_node/Pattern-Rules.html
+ * - comments starting with #
  */
-const excludesRegex = /^[.%]/;
-const targetNameRegex = /^([\w-./ ]+)\s*:(?![:=?])/i;
+const excludesRegex = /^[.%#]|:=/;
+const targetNameRegex = /^([\w-./ ]+)\s*:/i;
 
 export async function makefileParser(makefileFsPath: string): Promise<string[] | null> {
   try {
@@ -34,6 +35,10 @@ export async function makefileParser(makefileFsPath: string): Promise<string[] |
  * Returns the target name or null if it doesn't match
  */
 export function targetNameMatcher(line: string): string | null {
+  if (excludesRegex.test(line)) {
+    return null;
+  }
+
   const match = targetNameRegex.exec(line);
 
   if (!match?.[1]) {
@@ -41,10 +46,5 @@ export function targetNameMatcher(line: string): string | null {
   }
 
   const targetName = match[1].trim();
-
-  if (excludesRegex.test(targetName)) {
-    return null;
-  }
-
   return targetName;
 }

--- a/src/Tasks/getAvailableTasks.test.ts
+++ b/src/Tasks/getAvailableTasks.test.ts
@@ -1,3 +1,5 @@
+import { makeTasksResult } from '../test/examples/case-1/expectedResults';
+
 import getAvailableTasks from './getAvailableTasks';
 import { MakefileTask } from './MakefileTask';
 import { getCachedTasks, invalidateTaskCaches, setCachedTasks } from './taskCaches';
@@ -17,11 +19,11 @@ describe('Get Available Tasks', () => {
 
   it('should parse the Makefile and return the tasks', async () => {
     const tasks = await getAvailableTasks();
-    expect(tasks).to.have.length(3);
+    expect(tasks).to.have.length(makeTasksResult.length);
 
     const cachedTasks = getCachedTasks();
     expect(tasks).to.equal(cachedTasks);
 
-    expect(tasks.map((t) => t.name)).deep.equal(['foo', 'build', 'test']);
+    expect(tasks.map((t) => t.name)).deep.equal(makeTasksResult);
   });
 });

--- a/src/test/examples/case-1/Makefile
+++ b/src/test/examples/case-1/Makefile
@@ -13,3 +13,13 @@ test:
 var_1 := "variable test 1"
 var_2 ::= "variable posix"
 var_3 ?= "optional variable"
+
+# Double colon rule
+# https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html
+double-colon::
+	echo "double colon"
+
+double-colon-with-space ::
+	echo "double colon with space"
+
+double-requisites:: test

--- a/src/test/examples/case-1/expectedResults.ts
+++ b/src/test/examples/case-1/expectedResults.ts
@@ -1,0 +1,12 @@
+/**
+ * The expected tasks after parsing the Makefile
+ * Used for testing
+ */
+export const makeTasksResult = [
+  'foo',
+  'build',
+  'test',
+  'double-colon',
+  'double-colon-with-space',
+  'double-requisites',
+];


### PR DESCRIPTION
From the Docs:
> Double-colon rules are explicit rules written with ‘::’ instead of ‘:’

```makefile
normal-rule: 
  echo normal

double-colon::
  echo "double colon"
```

fixes #29 

[double colon rules Docs](https://www.gnu.org/software/make/manual/html_node/Double_002dColon.html)